### PR TITLE
DTO 들에 Serializable 인터페이스 제거

### DIFF
--- a/src/main/java/com/jake/projectboard/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/com/jake/projectboard/dto/response/ArticleCommentResponse.java
@@ -11,7 +11,7 @@ public record ArticleCommentResponse(
     LocalDateTime createdAt,
     String email,
     String nickname
-) implements Serializable {
+) {
     public static ArticleCommentResponse of(Long id,
                                             String content,
                                             LocalDateTime createdAt,

--- a/src/main/java/com/jake/projectboard/dto/response/ArticleResponse.java
+++ b/src/main/java/com/jake/projectboard/dto/response/ArticleResponse.java
@@ -16,7 +16,7 @@ public record ArticleResponse(
         LocalDateTime createdAt,
         String email,
         String nickname
-) implements Serializable {
+) {
     public static ArticleResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname) {
         return new ArticleResponse(id, title, content, hashtag, createdAt, email, nickname);
     }

--- a/src/main/java/com/jake/projectboard/dto/response/ArticleWithCommentsResponse.java
+++ b/src/main/java/com/jake/projectboard/dto/response/ArticleWithCommentsResponse.java
@@ -17,7 +17,7 @@ public record ArticleWithCommentsResponse(
         String email,
         String nickname,
         Set<ArticleCommentResponse> articleCommentsResponse
-) implements Serializable {
+) {
     public static ArticleWithCommentsResponse of(Long id,
                                                  String title,
                                                  String content,


### PR DESCRIPTION
JPA Buddy 를 이용해 작성한 DTO들인데,
자동으로 implements Serializable 이 들어가버림
우리 프로젝트는 직렬화로 Jackson을 사용하므로
필요하지 않고, 의도하여 넣은 코드도 아님
그러므로 삭제