### PR TITLE
엔티티 equals() 버그 수정

### DIFF
--- a/src/main/java/com/jake/projectboard/domain/Article.java
+++ b/src/main/java/com/jake/projectboard/domain/Article.java
@@ -65,8 +65,8 @@ public class Article extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Article article)) return false; // pattern variable 방식
-        return id != null && id.equals(article.id);
+        if (!(o instanceof Article that)) return false; // pattern variable 방식
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/src/main/java/com/jake/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/jake/projectboard/domain/ArticleComment.java
@@ -50,7 +50,7 @@ public class ArticleComment extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return id != null && id.equals(that.getId());
     }
 
     @Override

--- a/src/main/java/com/jake/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/jake/projectboard/domain/UserAccount.java
@@ -49,9 +49,9 @@ public class UserAccount extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof UserAccount userAccount)) return false;
+        if (!(o instanceof UserAccount that)) return false;
 //        return id != null && id.equals(userAccount.id);
-        return userId != null && userId.equals(userAccount.userId);
+        return userId != null && userId.equals(that.getUserId());
     }
 
     @Override

--- a/src/main/java/com/jake/projectboard/service/ArticleService.java
+++ b/src/main/java/com/jake/projectboard/service/ArticleService.java
@@ -75,7 +75,7 @@ public class ArticleService {
             Article article = articleRepository.getReferenceById(articleId);
             UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().userId());
 
-            if ( article.getUserAccount().equals(userAccount)) {
+            if (article.getUserAccount().equals(userAccount)) {
                 if (dto.title() != null) {
                     article.setTitle(dto.title());
                 }


### PR DESCRIPTION
테스트해 보니 `that.id`와 같은 표현은
의도하지 않은 동작을 만들었다.
제대로 getter 를 써서 값을 불러오게 수정
이름도 `that`으로 통일